### PR TITLE
Update to Open SDG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # sdg-indicators
+
+...


### PR DESCRIPTION
@A-L-Fearon I wanted to extend an offer of help in case you might be interested in updating this repo to use [Open SDG](https://github.com/open-sdg/open-sdg). Since the time this was originally forked, the [US](https://sdg.data.gov/) and the [UK](https://sustainabledevelopment-uk.github.io/) have both updated. Open SDG is, in a nutshell, a Jekyll theme based on the US/UK platforms, so switching over is not too difficult. I'd be happy to use this pull-request to show the code changes that are involved, if you're interested.

Here is more [documentation](https://open-sdg.readthedocs.io/en/latest/) about it. Feel free to reach out if you've got any questions/concerns about this approach.
